### PR TITLE
feat: support for SCSS files in Requirements::themedCSS()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ class PageController extends ContentController
     {
         parent::init();
         Requirements::css('themes/site/css/stylesheet.scss');
+        // OR
+        Requirements::themedCSS('css/stylesheet.scss');
     }
 }
 ```

--- a/docs/en/Usage.md
+++ b/docs/en/Usage.md
@@ -20,7 +20,7 @@ class PageController extends ContentController
 }
 ```
 
-The library supports `themedCSS()` file resolving mechanism. The following 3 liines are equivalent:
+The library supports `themedCSS()` file resolving mechanism. The following 3 lines are equivalent:
 ```php
 Requirements::css('themes/site/scss/main.scss');
 Requirements::themedCSS('scss/main.scss');
@@ -29,6 +29,8 @@ Requirements::themedCSS('main');
 
 This will parse the scss file (if needed), and write the resulting CSS file to `assets/_css/themes-site-css-stylesheet.css`
 and automatically link the CSS in the templates to that file.
+
+Note that the lookups for SCSS files (when no folder provided in path) are done in `scss` folder (not `css`).
 
 This also works if you are combining files:
 
@@ -67,9 +69,13 @@ Requirements::process_combined_files();
 
 You can also include scss stylesheets from within your templates:
 ```
-<% require css(themes/site/css/stylesheet.scss) %>
+<% require css(themes/site/scss/stylesheet.scss) %>
 <!-- OR -->
-<% require themedCSS(css/stylesheet.scss) %>
+<% require themedCSS(scss/stylesheet.scss) %>
+<!-- OR -->
+<% require themedCSS(stylesheet.scss) %>
+<!-- OR -->
+<% require themedCSS(stylesheet) %>
 ```
 
 ## Using custom variables and `$ThemeDir`

--- a/docs/en/Usage.md
+++ b/docs/en/Usage.md
@@ -20,6 +20,13 @@ class PageController extends ContentController
 }
 ```
 
+The library supports `themedCSS()` file resolving mechanism. The following 3 liines are equivalent:
+```php
+Requirements::css('themes/site/scss/main.scss');
+Requirements::themedCSS('scss/main.scss');
+Requirements::themedCSS('main');
+```
+
 This will parse the scss file (if needed), and write the resulting CSS file to `assets/_css/themes-site-css-stylesheet.css`
 and automatically link the CSS in the templates to that file.
 
@@ -44,9 +51,25 @@ class PageController extends ContentController
 }
 ```
 
+For the sake of filename resolving to use in `Requirements::combine_files`, you can use `Requirements::findThemedSCSS()`:
+```php
+<?php
+use SilverStripe\View\Requirements;
+use Axllent\Scss\ScssCompiler;
+
+// ...
+Requirements::combine_files('combined.css', [
+    ScssCompiler::findThemedSCSS('css/stylesheet'),
+    ScssCompiler::findThemedSCSS('css/colours'),
+]);
+Requirements::process_combined_files();
+```
+
 You can also include scss stylesheets from within your templates:
 ```
 <% require css(themes/site/css/stylesheet.scss) %>
+<!-- OR -->
+<% require themedCSS(css/stylesheet.scss) %>
 ```
 
 ## Using custom variables and `$ThemeDir`

--- a/src/ScssCompiler.php
+++ b/src/ScssCompiler.php
@@ -173,16 +173,16 @@ class ScssCompiler extends Requirements_Backend implements Flushable
      */
     public function themedCSS($name, $media = null)
     {
-        $path = ThemeResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
+        $path = self::findThemedSCSS($name, SSViewer::get_themes());
         if ($path) {
             $this->css($path, $media);
         } else {
-            $path = self::findThemedSCSS($name, SSViewer::get_themes());
+            $path = ThemeResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
             if ($path) {
                 $this->css($path, $media);
             } else {
                 throw new InvalidArgumentException(
-                    "The css file doesn't exist. Please check if the file $name.css exists in any context or search for "
+                    "The css/scss file doesn't exist. Please check if the file $name.css (or $name.scss) exists in any context or search for "
                     . "themedCSS references calling this file in your templates."
                 );
             }

--- a/src/ScssCompiler.php
+++ b/src/ScssCompiler.php
@@ -126,7 +126,7 @@ class ScssCompiler extends Requirements_Backend implements Flushable
             $themes = SSViewer::get_themes();
         }
 
-        if (substr($name, -4) !== '.scss') {
+        if (substr($name, -5) !== '.scss') {
             $name .= '.scss';
         }
         $filename = ThemeResourceLoader::inst()->findThemedResource("scss/$name", $themes);


### PR DESCRIPTION
I felt the need for this for a while.

Adds support for the following code:

```php
Requirements::themedCSS('css/main.scss');
Requirements::themedCSS('css/main');
```

```php
<?php
use SilverStripe\View\Requirements;
use Axllent\Scss\ScssCompiler;

// ...
Requirements::combine_files('combined.css', [
    ScssCompiler::findThemedSCSS('css/stylesheet'),
    ScssCompiler::findThemedSCSS('css/colours'),
]);
Requirements::process_combined_files();
```

```
<% require themedCSS(css/stylesheet.scss) %>
```